### PR TITLE
squid:S3052 - Fields should not be initialized to default values

### DIFF
--- a/zxing-orient/src/main/java/com/google/zxing/oned/rss/expanded/RSSExpandedReader.java
+++ b/zxing-orient/src/main/java/com/google/zxing/oned/rss/expanded/RSSExpandedReader.java
@@ -118,7 +118,7 @@ public final class RSSExpandedReader extends AbstractRSSReader {
   private final List<ExpandedRow> rows = new ArrayList<>();
   private final int [] startEnd = new int[2];
   //private final int [] currentSequence = new int[LONGEST_SEQUENCE_SIZE];
-  private boolean startFromEven = false;
+  private boolean startFromEven;
 
   @Override
   public Result decodeRow(int rowNumber,


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S3052 - Fields should not be initialized to default values

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S3052

Please let me know if you have any questions.

M-Ezzat
