### PR TITLE
squid:UselessParenthesesCheck - Useless parentheses around expression…

### DIFF
--- a/zxing-orient/src/main/java/com/google/zxing/common/BitArray.java
+++ b/zxing-orient/src/main/java/com/google/zxing/common/BitArray.java
@@ -307,7 +307,7 @@ public final class BitArray implements Cloneable {
   public void reverse() {
     int[] newBits = new int[bits.length];
     // reverse all int's first
-    int len = ((size-1) / 32);
+    int len = (size-1) / 32;
     int oldBitsLen = len + 1;
     for (int i = 0; i < oldBitsLen; i++) {
       long x = (long) bits[i];

--- a/zxing-orient/src/main/java/com/google/zxing/pdf417/encoder/PDF417HighLevelEncoder.java
+++ b/zxing-orient/src/main/java/com/google/zxing/pdf417/encoder/PDF417HighLevelEncoder.java
@@ -399,7 +399,7 @@ final class PDF417HighLevelEncoder {
     if (count == 1 && startmode == TEXT_COMPACTION) {
       sb.append((char) SHIFT_TO_BYTE);
     } else {
-      boolean sixpack = ((count % 6) == 0);
+      boolean sixpack = (count % 6) == 0;
       if (sixpack) {
         sb.append((char)LATCH_TO_BYTE);
       } else {

--- a/zxing-orient/src/main/java/com/google/zxing/qrcode/decoder/FormatInformation.java
+++ b/zxing-orient/src/main/java/com/google/zxing/qrcode/decoder/FormatInformation.java
@@ -86,13 +86,13 @@ final class FormatInformation {
     a ^= b; // a now has a 1 bit exactly where its bit differs with b's
     // Count bits set quickly with a series of lookups:
     return BITS_SET_IN_HALF_BYTE[a & 0x0F] +
-        BITS_SET_IN_HALF_BYTE[(a >>> 4 & 0x0F)] +
-        BITS_SET_IN_HALF_BYTE[(a >>> 8 & 0x0F)] +
-        BITS_SET_IN_HALF_BYTE[(a >>> 12 & 0x0F)] +
-        BITS_SET_IN_HALF_BYTE[(a >>> 16 & 0x0F)] +
-        BITS_SET_IN_HALF_BYTE[(a >>> 20 & 0x0F)] +
-        BITS_SET_IN_HALF_BYTE[(a >>> 24 & 0x0F)] +
-        BITS_SET_IN_HALF_BYTE[(a >>> 28 & 0x0F)];
+        BITS_SET_IN_HALF_BYTE[a >>> 4 & 0x0F] +
+        BITS_SET_IN_HALF_BYTE[a >>> 8 & 0x0F] +
+        BITS_SET_IN_HALF_BYTE[a >>> 12 & 0x0F] +
+        BITS_SET_IN_HALF_BYTE[a >>> 16 & 0x0F] +
+        BITS_SET_IN_HALF_BYTE[a >>> 20 & 0x0F] +
+        BITS_SET_IN_HALF_BYTE[a >>> 24 & 0x0F] +
+        BITS_SET_IN_HALF_BYTE[a >>> 28 & 0x0F];
   }
 
   /**

--- a/zxing-orient/src/main/java/me/sudar/zxingorient/ZxingOrient.java
+++ b/zxing-orient/src/main/java/me/sudar/zxingorient/ZxingOrient.java
@@ -122,7 +122,7 @@ public class ZxingOrient {
 //        intentScan.putExtra((Intents.Scan.FLASH), flash);
 
         intentScan.putExtra(Intents.Scan.VIBRATE, vibrate);
-        intentScan.putExtra((Intents.Scan.BEEP), playBeep);
+        intentScan.putExtra(Intents.Scan.BEEP, playBeep);
 
         if(iconID != null) intentScan.putExtra(Intents.Scan.ICON_ID,iconID);
         if(toolbarColor != null) intentScan.putExtra(Intents.Scan.TOOLBAR_COLOR,toolbarColor);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:UselessParenthesesCheck

Please let me know if you have any questions.

M-Ezzat
