### PR TITLE
squid:SwitchLastCaseIsDefaultCheck - switch statements should end wit…

### DIFF
--- a/app/src/main/java/me/sudar/zxingorient/demo/MainActivity.java
+++ b/app/src/main/java/me/sudar/zxingorient/demo/MainActivity.java
@@ -97,6 +97,8 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
                 else
                     new ZxingOrient(MainActivity.this).shareText(shareEditText.getText().toString());
                 break;
+            default:
+                break;
         }
     }
 
@@ -181,6 +183,8 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
                 }
             }
             break;
+            default:
+                break;
         }
     }
 

--- a/zxing-orient/src/main/java/com/google/zxing/client/android/CaptureActivity.java
+++ b/zxing-orient/src/main/java/com/google/zxing/client/android/CaptureActivity.java
@@ -317,6 +317,8 @@ public final class CaptureActivity extends Activity implements SurfaceHolder.Cal
             case KeyEvent.KEYCODE_CAMERA:
                 // Handle these events so they don't launch the Camera app
                 return true;
+            default:
+                break;
         }
         return super.onKeyDown(keyCode, event);
     }

--- a/zxing-orient/src/main/java/com/google/zxing/client/android/HttpHelper.java
+++ b/zxing-orient/src/main/java/com/google/zxing/client/android/HttpHelper.java
@@ -188,6 +188,8 @@ public final class HttpHelper {
               // nevermind
             }
           }
+          default:
+            break;
       }
       return uri;
     } finally {

--- a/zxing-orient/src/main/java/com/google/zxing/client/android/encode/QRCodeEncoder.java
+++ b/zxing-orient/src/main/java/com/google/zxing/client/android/encode/QRCodeEncoder.java
@@ -309,6 +309,8 @@ final class QRCodeEncoder {
         }
         break;
       }
+      default:
+        break;
     }
   }
 

--- a/zxing-orient/src/main/java/com/google/zxing/client/result/VINResultParser.java
+++ b/zxing-orient/src/main/java/com/google/zxing/client/result/VINResultParser.java
@@ -202,6 +202,8 @@ public final class VINResultParser extends ResultParser {
           return "IT";
         }
         break;
+      default:
+        break;
     }
     return null;
   }

--- a/zxing-orient/src/main/java/com/google/zxing/maxicode/decoder/DecodedBitStreamParser.java
+++ b/zxing-orient/src/main/java/com/google/zxing/maxicode/decoder/DecodedBitStreamParser.java
@@ -88,6 +88,8 @@ final class DecodedBitStreamParser {
       case 5:
         result.append(getMessage(bytes, 1, 77));
         break;
+      default:
+        break;
     }
     return new DecoderResult(bytes, result.toString(), null, String.valueOf(mode));
   }

--- a/zxing-orient/src/main/java/com/google/zxing/oned/CodaBarWriter.java
+++ b/zxing-orient/src/main/java/com/google/zxing/oned/CodaBarWriter.java
@@ -83,6 +83,8 @@ public final class CodaBarWriter extends OneDimensionalCodeWriter {
           case 'E':
             c = 'D';
             break;
+          default:
+            break;
         }
       }
       int code = 0;

--- a/zxing-orient/src/main/java/com/google/zxing/oned/Code128Reader.java
+++ b/zxing-orient/src/main/java/com/google/zxing/oned/Code128Reader.java
@@ -312,6 +312,8 @@ public final class Code128Reader extends OneDReader {
         case CODE_START_B:
         case CODE_START_C:
           throw FormatException.getFormatInstance();
+        default:
+          break;
       }
 
       switch (codeSet) {
@@ -377,6 +379,8 @@ public final class Code128Reader extends OneDReader {
                 break;
               case CODE_STOP:
                 done = true;
+                break;
+              default:
                 break;
             }
           }
@@ -471,6 +475,8 @@ public final class Code128Reader extends OneDReader {
                 break;
             }
           }
+          break;
+        default:
           break;
       }
 

--- a/zxing-orient/src/main/java/com/google/zxing/oned/Code39Reader.java
+++ b/zxing-orient/src/main/java/com/google/zxing/oned/Code39Reader.java
@@ -309,6 +309,8 @@ public final class Code39Reader extends OneDReader {
               throw FormatException.getFormatInstance();
             }
             break;
+          default:
+            break;
         }
         decoded.append(decodedChar);
         // bump up i again since we read two characters

--- a/zxing-orient/src/main/java/com/google/zxing/oned/Code93Reader.java
+++ b/zxing-orient/src/main/java/com/google/zxing/oned/Code93Reader.java
@@ -242,6 +242,8 @@ public final class Code93Reader extends OneDReader {
               throw FormatException.getFormatInstance();
             }
             break;
+          default:
+            break;
         }
         decoded.append(decodedChar);
         // bump up i again since we read two characters

--- a/zxing-orient/src/main/java/com/google/zxing/oned/rss/expanded/decoders/AbstractExpandedDecoder.java
+++ b/zxing-orient/src/main/java/com/google/zxing/oned/rss/expanded/decoders/AbstractExpandedDecoder.java
@@ -67,12 +67,14 @@ public abstract class AbstractExpandedDecoder {
     switch(fourBitEncodationMethod){
       case 4: return new AI013103decoder(information);
       case 5: return new AI01320xDecoder(information);
+      default: break;
     }
 
     int fiveBitEncodationMethod = GeneralAppIdDecoder.extractNumericValueFromBitArray(information, 1, 5);
     switch(fiveBitEncodationMethod){
       case 12: return new AI01392xDecoder(information);
       case 13: return new AI01393xDecoder(information);
+      default: break;
     }
 
     int sevenBitEncodationMethod = GeneralAppIdDecoder.extractNumericValueFromBitArray(information, 1, 7);
@@ -85,6 +87,7 @@ public abstract class AbstractExpandedDecoder {
       case 61: return new AI013x0x1xDecoder(information, "320", "15");
       case 62: return new AI013x0x1xDecoder(information, "310", "17");
       case 63: return new AI013x0x1xDecoder(information, "320", "17");
+      default: break;
     }
 
     throw new IllegalStateException("unknown decoder: " + information);

--- a/zxing-orient/src/main/java/com/google/zxing/pdf417/decoder/DecodedBitStreamParser.java
+++ b/zxing-orient/src/main/java/com/google/zxing/pdf417/decoder/DecodedBitStreamParser.java
@@ -1,4 +1,4 @@
-/*
+2/*
  * Copyright 2009 ZXing authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -236,6 +236,8 @@ final class DecodedBitStreamParser {
             byteCompactionData[index] = code;
             index++;
             break;
+          default:
+            break;
         }
       }
     }
@@ -393,6 +395,8 @@ final class DecodedBitStreamParser {
               subMode = Mode.ALPHA;
             }
           }
+          break;
+        default:
           break;
       }
       if (ch != 0) {

--- a/zxing-orient/src/main/java/com/google/zxing/pdf417/decoder/DetectionResultRowIndicatorColumn.java
+++ b/zxing-orient/src/main/java/com/google/zxing/pdf417/decoder/DetectionResultRowIndicatorColumn.java
@@ -199,6 +199,8 @@ final class DetectionResultRowIndicatorColumn extends DetectionResultColumn {
         case 2:
           barcodeColumnCount.setValue(rowIndicatorValue + 1);
           break;
+        default:
+          break;
       }
     }
     // Maybe we should check if we have ambiguous values?
@@ -250,6 +252,8 @@ final class DetectionResultRowIndicatorColumn extends DetectionResultColumn {
           if (rowIndicatorValue + 1 != barcodeMetadata.getColumnCount()) {
             codewords[codewordRow] = null;
           }
+          break;
+        default:
           break;
       }
     }

--- a/zxing-orient/src/main/java/com/google/zxing/qrcode/detector/Detector.java
+++ b/zxing-orient/src/main/java/com/google/zxing/qrcode/detector/Detector.java
@@ -212,6 +212,8 @@ public class Detector {
         break;
       case 3:
         throw NotFoundException.getNotFoundInstance();
+      default:
+        break;
     }
     return dimension;
   }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:SwitchLastCaseIsDefaultCheck - "switch" statements should end with a "default" clause

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:SwitchLastCaseIsDefaultCheck

Please let me know if you have any questions.

M-Ezzat
